### PR TITLE
Closes #149 -- Add Podman support for local dev and build

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,10 @@
+FROM node:22-alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm install
+
+EXPOSE 8080
+
+CMD ["npm", "start"]

--- a/scripts/podman.sh
+++ b/scripts/podman.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+IMAGE="linux-victoria-website"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+usage() {
+  cat <<EOF
+Usage: scripts/podman.sh <command> [options]
+
+Commands:
+  dev [port]  Build image and run the dev server on port (default: 8080).
+              Exits with an error if the port is already in use.
+  build       Run the production build inside a container.
+              Output is written to _site/ on the host.
+  shell       Open a shell inside the container for debugging.
+EOF
+}
+
+build_image() {
+  podman build -t "$IMAGE" -f "$ROOT/Containerfile" "$ROOT"
+}
+
+case "${1:-}" in
+  dev)
+    PORT="${2:-8080}"
+    if ss -tlnH "sport = :$PORT" 2>/dev/null | grep -q .; then
+      echo "Error: port $PORT is already in use." >&2
+      echo "Try: scripts/podman.sh dev <port>" >&2
+      exit 1
+    fi
+    build_image
+    podman run --rm -it \
+      -p "$PORT:8080" \
+      -v "$ROOT:/app:z" \
+      -v /app/node_modules \
+      "$IMAGE" npm start
+    ;;
+  build)
+    build_image
+    podman run --rm \
+      -v "$ROOT:/app:z" \
+      "$IMAGE" npm run build
+    ;;
+  shell)
+    build_image
+    podman run --rm -it \
+      -v "$ROOT:/app:z" \
+      "$IMAGE" sh
+    ;;
+  *)
+    usage
+    ;;
+esac


### PR DESCRIPTION
Adds a Containerfile (Node 22 Alpine) and scripts/podman.sh for running the site without needing Node installed locally.

  scripts/podman.sh dev [port]  — dev server with live reload (default: 8080)
  scripts/podman.sh build       — production build, outputs to _site/
  scripts/podman.sh shell       — shell into the container for debugging

The dev command mounts source as a volume so edits on the host trigger Eleventy rebuilds. An anonymous volume over /app/node_modules prevents the host tree from shadowing the container's installed packages.

If the requested port is already in use, the command exits with a clear error rather than silently picking another port.