### PR TITLE
Fix Linux Regional Summit redirect

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,4 +1,5 @@
 /posts/2025-08-05_Town-Hall-Meeting-August  /posts/2025-08-12_Town-Hall-Meeting-August  301
+/linux-regional-summit   /events/2025-08-25_Linux-Regional-Summit   301!
 /linux-regional-discourse   /posts/2025-08-25_linux_regional_summit/#linux-regional-discourse   301!
 /volunteer-form*   /contact   301!
 /posts/2025-05-06_Town-Hall-Meeting  /posts/2025-05-06_Town-Hall-Meeting-May  301!


### PR DESCRIPTION
Closes #151

## Summary
- add a Netlify redirect for `/linux-regional-summit`
- point the broken short URL to the existing Linux Regional Summit event page

## Verification
- `curl -I -L --max-time 15 https://linuxvictoria.org/linux-regional-summit` returned HTTP 404 before this fix
- `npm run build`